### PR TITLE
Add Composer start script and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Índice SaaS
+
+Proyecto PHP modular.
+
+## Desarrollo
+
+Inicia un servidor local con:
+
+```
+composer start
+```
+
+Esto ejecuta el servidor interno de PHP en `http://localhost:8000` utilizando la carpeta `public/` como documento raíz.
+

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     },
     "scripts": {
         "lint": "phpcs --standard=PSR12 src admin panel_root",
-        "migrate": "php database/migrate.php"
+        "migrate": "php database/migrate.php",
+        "start": "php -S localhost:8000 -t public"
     }
 }


### PR DESCRIPTION
## Summary
- add `start` script to launch PHP built-in server
- document `composer start` usage in README

## Testing
- `composer lint` *(fails: The file "admin" does not exist)*
- `vendor/bin/phpcs --standard=PSR12 src` *(fails: code style violations)*

------
https://chatgpt.com/codex/tasks/task_e_68af7a3f085c8332a4a0829b3acb0adb