### PR TITLE
Restrict lint script to src directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
         "squizlabs/php_codesniffer": "^3.9"
     },
     "scripts": {
-        "lint": "phpcs --standard=PSR12 src admin panel_root",
+        "lint": "phpcs --standard=PSR12 src",
         "migrate": "php database/migrate.php",
         "start": "php -S localhost:8000 -t public"
     }


### PR DESCRIPTION
## Summary
- simplify composer lint script to check only the src directory

## Testing
- `composer lint` *(fails: PSR12 violations across multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68af7bcee854833281f5c59d528fed9f