### PR TITLE
Fix include paths for public front controller

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1,10 +1,9 @@
-
 <?php
 // Front-controller principal
 
 // Cargar helpers y configuración
-require_once __DIR__ . '/src/core/helpers.php';
-require_once __DIR__ . '/config/routes.php';
+require_once __DIR__ . '/../src/core/helpers.php';
+require_once __DIR__ . '/../config/routes.php';
 
 // Ejemplo de router básico
 $route = $_GET['route'] ?? 'home';


### PR DESCRIPTION
## Summary
- reference helpers and routes using paths relative to the public directory
- remove leading whitespace to avoid headers-already-sent warnings

## Testing
- `php -l public/index.php`
- `php -S 127.0.0.1:8000 -t public` and `curl -s 127.0.0.1:8000/`

------
https://chatgpt.com/codex/tasks/task_e_68af7caa62a883328aa6c7e7b1d74c97