### PR TITLE
Add basic translation helper and keys

### DIFF
--- a/index.php
+++ b/index.php
@@ -24,18 +24,18 @@ function renderPage($title, $content) {
 
 $route = $_GET['route'] ?? 'home';
 switch ($route) {
-	case 'admin':
-		ob_start();
-		require __DIR__ . '/src/admin/index.php';
-		$content = ob_get_clean();
-		renderPage('Panel Admin', $content);
-		break;
-	case 'auth':
-		ob_start();
-		require __DIR__ . '/src/auth/index.php';
-		$content = ob_get_clean();
-		renderPage('Login', $content);
-		break;
+        case 'admin':
+                ob_start();
+                require __DIR__ . '/src/admin/index.php';
+                $content = ob_get_clean();
+                renderPage(t('admin.panel'), $content);
+                break;
+        case 'auth':
+                ob_start();
+                require __DIR__ . '/src/auth/index.php';
+                $content = ob_get_clean();
+                renderPage(t('login.title'), $content);
+                break;
 	case 'panel_root':
 		ob_start();
 		require __DIR__ . '/src/panel_root/index.php';
@@ -48,7 +48,7 @@ switch ($route) {
 			.'<h1 class="display-5 text-center mb-3">Bienvenido a Indice SaaS</h1>'
 			.'<p class="lead text-center mb-4">Gestiona empresas, roles y módulos en una plataforma SaaS moderna y escalable.</p>'
 			.'<div class="d-grid gap-2">'
-			.'<a href="?route=auth" class="btn btn-primary btn-lg">Ingresar</a>'
+                        .'<a href="?route=auth" class="btn btn-primary btn-lg">' . t('login.submit') . '</a>'
 			.'<a href="?route=admin" class="btn btn-outline-secondary">Ver demo admin</a>'
 			.'<a href="?route=panel_root" class="btn btn-outline-secondary">Ver demo root</a>'
 			.'</div>'

--- a/lang/en.php
+++ b/lang/en.php
@@ -1,3 +1,12 @@
 <?php
 // English translations
-return [];
+return [
+    'login.title' => 'Login',
+    'login.email' => 'Email',
+    'login.password' => 'Password',
+    'login.submit' => 'Login',
+    'login.error' => 'Invalid login',
+    'admin.panel' => 'Admin Panel — Invitations and company management',
+    'admin.description' => 'Here you can send invitations and manage the company.',
+    'admin.placeholder' => 'Invitation and management functionality coming soon...'
+];

--- a/lang/es.php
+++ b/lang/es.php
@@ -1,3 +1,12 @@
 <?php
 // Traducciones español
-return [];
+return [
+    'login.title' => 'Iniciar sesión',
+    'login.email' => 'Correo electrónico',
+    'login.password' => 'Contraseña',
+    'login.submit' => 'Ingresar',
+    'login.error' => 'Login incorrecto',
+    'admin.panel' => 'Panel Admin — Invitaciones y gestión de empresa',
+    'admin.description' => 'Aquí puedes enviar invitaciones y administrar la empresa.',
+    'admin.placeholder' => 'Funcionalidad de invitaciones y gestión próximamente...'
+];

--- a/src/admin/index.php
+++ b/src/admin/index.php
@@ -6,15 +6,15 @@ require_once __DIR__ . '/../core/helpers.php';
 auth();
 checkRole(['admin','superadmin']);
 
-echo '<h2>Panel Admin — Invitaciones y gestión de empresa</h2>';
+echo '<h2>' . t('admin.panel') . '</h2>';
 echo '<div class="row justify-content-center mt-5">';
 echo '<div class="col-md-8 col-lg-6">';
 echo '<div class="card shadow">';
 echo '<div class="card-body">';
-echo '<h2 class="mb-4 text-center">Panel Admin — Invitaciones y gestión de empresa</h2>';
-echo '<p class="lead">Aquí puedes enviar invitaciones y administrar la empresa.</p>';
+echo '<h2 class="mb-4 text-center">' . t('admin.panel') . '</h2>';
+echo '<p class="lead">' . t('admin.description') . '</p>';
 // Aquí iría la lógica para enviar invitaciones y administrar la empresa
-echo '<div class="alert alert-info">Funcionalidad de invitaciones y gestión próximamente...</div>';
+echo '<div class="alert alert-info">' . t('admin.placeholder') . '</div>';
 echo '</div>';
 echo '</div>';
 echo '</div>';

--- a/src/auth/index.php
+++ b/src/auth/index.php
@@ -2,7 +2,6 @@
 /**
  * Login, registro y logout básicos
  */
-session_start();
 require_once __DIR__ . '/../core/helpers.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -12,29 +11,29 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 	$stmt = $db->prepare('SELECT id, password_hash FROM users WHERE email = ? AND is_active = 1');
 	$stmt->execute([$email]);
 	$user = $stmt->fetch(PDO::FETCH_ASSOC);
-	if ($user && password_verify($pass, $user['password_hash'])) {
-		$_SESSION['user_id'] = $user['id'];
-		header('Location: /panel_root/index.php');
-		exit;
-	} else {
-		echo '<p style="color:red">Login incorrecto</p>';
-	}
+        if ($user && password_verify($pass, $user['password_hash'])) {
+                $_SESSION['user_id'] = $user['id'];
+                header('Location: /panel_root/index.php');
+                exit;
+        } else {
+                echo '<p style="color:red">' . t('login.error') . '</p>';
+        }
 }
 echo '<div class="row justify-content-center mt-5">';
 echo '<div class="col-md-6 col-lg-4">';
 echo '<div class="card shadow">';
 echo '<div class="card-body">';
-echo '<h2 class="mb-4 text-center">Login</h2>';
+echo '<h2 class="mb-4 text-center">' . t('login.title') . '</h2>';
 echo '<form method="post">';
 echo '<div class="mb-3">';
-echo '<label for="email" class="form-label">Email</label>';
+echo '<label for="email" class="form-label">' . t('login.email') . '</label>';
 echo '<input name="email" id="email" class="form-control" autocomplete="username">';
 echo '</div>';
 echo '<div class="mb-3">';
-echo '<label for="password" class="form-label">Password</label>';
+echo '<label for="password" class="form-label">' . t('login.password') . '</label>';
 echo '<input name="password" id="password" type="password" class="form-control" autocomplete="current-password">';
 echo '</div>';
-echo '<button type="submit" class="btn btn-primary w-100">Ingresar</button>';
+echo '<button type="submit" class="btn btn-primary w-100">' . t('login.submit') . '</button>';
 echo '</form>';
 echo '</div>';
 echo '</div>';

--- a/src/core/helpers.php
+++ b/src/core/helpers.php
@@ -5,6 +5,16 @@
 
 session_start();
 
+function t(string $key): string {
+        $lang = $_SESSION['lang'] ?? 'es';
+        static $cache = [];
+        if (!isset($cache[$lang])) {
+                $file = __DIR__ . "/../../lang/{$lang}.php";
+                $cache[$lang] = file_exists($file) ? include $file : [];
+        }
+        return $cache[$lang][$key] ?? $key;
+}
+
 function getDB() {
 	static $db = null;
 	if ($db === null) {


### PR DESCRIPTION
## Summary
- add Spanish/English translation files with login and admin keys
- introduce `t()` helper to load translations based on session language
- use translation helper in login, admin and router views

## Testing
- `php -l lang/es.php lang/en.php src/core/helpers.php src/auth/index.php src/admin/index.php index.php`
- `composer lint` *(fails: existing PSR-12 issues in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68af7e39dc488332bcaa973c728fdd1f